### PR TITLE
Role çalıştırma kontrolü eklendi

### DIFF
--- a/ahtapotmys/playbooks/ansible.yml
+++ b/ahtapotmys/playbooks/ansible.yml
@@ -32,7 +32,23 @@
   - ../roles/ansible/vars/conf_list.yml
   - ../roles/post/vars/integrity.yml
   - ../roles/post/vars/package.yml
+  vars_prompt:
+    - name: run_base
+      prompt: "Base rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
+    - name: run_ansible
+      prompt: "Ansible rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
+    - name: run_post
+      prompt: "Post rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
   roles:
-  - { role: base }
-  - { role: ansible }
-  - { role: post }
+  - { role: base, when: run_base == "E" or run_base == "e" }
+  - { role: ansible, when: run_ansible == "E" or run_ansible == "e" }
+  - { role: post, when: run_post == "E" or run_post == "e" }

--- a/ahtapotmys/playbooks/gitlab.yml
+++ b/ahtapotmys/playbooks/gitlab.yml
@@ -29,7 +29,23 @@
   - ../roles/gitlab/vars/conf_list.yml
   - ../roles/post/vars/integrity.yml
   - ../roles/post/vars/package.yml
+  vars_prompt:
+    - name: run_base
+      prompt: "Base rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
+    - name: run_gitlab
+      prompt: "Gitlab rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
+    - name: run_post
+      prompt: "Post rolu calistirilsin mi? (E/h)"
+      default: "E"
+      private: no
+      confirm: yes
   roles:
-  - { role: base }
-  - { role: gitlab }
-  - { role: post}
+  - { role: base, when: run_base == "E" or run_base == "e" }
+  - { role: gitlab, when: run_gitlab == "E" or run_gitlab == "e" }
+  - { role: post, when: run_post == "E" or run_post == "e" }


### PR DESCRIPTION
Ansible ve gitlab kurulumu sırasında bazı rollerin ilk çalıştırmada devre dışı bırakılıp daha sonradan tekrar aktif hale getirilmesi manuel olarak yapılmaktansa ansible'ın **vars_prompt** özelliği kullanılarak playbook çalıştırılması sırasında direk input olarak alındı. Konuyla ilgili gerekli kurulum dökümanları da güncellendi.