### PR TITLE
# Eger, X-Window kullanilacaksa, .XAuthority dosyasinin `root` kullan…

### DIFF
--- a/ahtapotmys/roles/firewallbuilder/templates/fwbuilder-ahtapot.sh.j2
+++ b/ahtapotmys/roles/firewallbuilder/templates/fwbuilder-ahtapot.sh.j2
@@ -2,5 +2,21 @@
 ## Burada yapilan degisikliklerin uzerine yazilir!!
 {{ ansible_managed }}
 
+# Eger, X-Window kullanilacaksa, .XAuthority dosyasinin `root` kullanicisi icin kopyalanmasi gerekmekte
+# .XAuthority, puty tarafindan, sadece login olunan kullanici icin olusturulur.
+# Burada da `sudo` kullanildigindan, ilk `ahtapotops` login olmussa; `ahtapotops` kullanicisi icin olusturulur.
+# `root` kullanicisi icin olusturulmaz. Zaten `root` kullanicisi islemleri sirasinda kullanilmiyor.
+# bu yuzden kopyalama sorun olusturmamali. Boylelikle farkli ayarlarla puty uzerinden login olundu ise
+# bu farkli ayarlar `root` icinde gecerli olacaktir. Obur turlu
+# `PuTTY X11 proxy: Authorisation not recognised gdys-gui.py: cannot connect to X server localhost:10.0`
+# hatasi alinir.
+# https://stackoverflow.com/a/49818515/1290868
+# https://stackoverflow.com/a/34255298/1290868
+
+if ! [ $(id -u) = 0 ] && [ "$(whoami)" = "ahtapotops" ]; then
+    echo "root kullanicisi icin .Xauthority dosyasi kopyalaniyor.."
+    sudo cp ~ahtapotops/.Xauthority ~root/.Xauthority
+fi
+
 # Ahtapot Gdys-Gui kisayol tanimlamasi
 alias gdys-gui='/usr/bin/sudo /usr/bin/python /var/opt/gdysgui/gdys-gui.py'


### PR DESCRIPTION
…icisi icin kopyalanmasi gerekmekte

# .XAuthority, puty tarafindan, sadece login olunan kullanici icin olusturulur.
# Burada da `sudo` kullanildigindan, ilk `ahtapotops` login olmussa; `ahtapotops` kullanicisi icin olusturulur.
# `root` kullanicisi icin olusturulmaz. Zaten `root` kullanicisi islemleri sirasinda kullanilmiyor.
# bu yuzden kopyalama sorun olusturmamali. Boylelikle farkli ayarlarla puty uzerinden login olundu ise
# bu farkli ayarlar `root` icinde gecerli olacaktir. Obur turlu
# `PuTTY X11 proxy: Authorisation not recognised gdys-gui.py: cannot connect to X server localhost:10.0`
# hatasi alinir.
# https://stackoverflow.com/a/49818515/1290868
# https://stackoverflow.com/a/34255298/1290868